### PR TITLE
Rebuild SubmenuButton when `onOpen` is called

### DIFF
--- a/packages/flutter/lib/src/material/menu_anchor.dart
+++ b/packages/flutter/lib/src/material/menu_anchor.dart
@@ -392,17 +392,11 @@ class _MenuAnchorState extends State<MenuAnchor> {
         NextFocusIntent: _MenuNextFocusAction(),
         DismissIntent: DismissMenuAction(controller: _menuController),
       },
-      child:  Builder(
+      child: Builder(
         key: _anchorKey,
         builder: (BuildContext context) {
-          if (widget.builder == null) {
-            return widget.child ?? const SizedBox();
-          }
-          return widget.builder!(
-            context,
-            _menuController,
-            widget.child,
-          );
+          return widget.builder?.call(context, _menuController, widget.child)
+              ?? widget.child ?? const SizedBox();
         },
       ),
     );
@@ -1889,6 +1883,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
             _waitingToFocusMenu = false;
           });
           _waitingToFocusMenu = true;
+          setState(() { /* Rebuild with updated controller.isOpen value */ });
         }
         widget.onOpen?.call();
       },
@@ -1900,9 +1895,7 @@ class _SubmenuButtonState extends State<SubmenuButton> {
         // once.
         ButtonStyle mergedStyle = widget.themeStyleOf(context)?.merge(widget.defaultStyleOf(context))
           ?? widget.defaultStyleOf(context);
-        if (widget.style != null) {
-          mergedStyle = widget.style!.merge(mergedStyle);
-        }
+        mergedStyle = widget.style?.merge(mergedStyle) ?? mergedStyle;
 
         void toggleShowMenu(BuildContext context) {
           if (controller._anchor == null) {

--- a/packages/flutter/test/material/menu_anchor_test.dart
+++ b/packages/flutter/test/material/menu_anchor_test.dart
@@ -3253,8 +3253,6 @@ void main() {
       // Test expanded state.
       await tester.tap(find.text('ABC'));
       await tester.pumpAndSettle();
-      debugPrint(
-          'Semantics after tap: ${semantics.generateTestSemanticsExpressionForCurrentSemanticsTree(DebugSemanticsDumpOrder.traversalOrder)}');
       expect(
         semantics,
         hasSemantics(


### PR DESCRIPTION
```dart
        child = MergeSemantics(
          child: Semantics(
            expanded: controller.isOpen,
            child: ...
          ),
       ),
```
didn't work because it depends on `controller.isOpen` but the widget doesn't automatically rebuild when `isOpen` changes.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read and followed the [Flutter Style Guide], including [Features we expect every widget to implement].
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[Features we expect every widget to implement]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#features-we-expect-every-widget-to-implement
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
